### PR TITLE
Fix: Dispose CancellationTokenSource Properly Within CancellationDisposable

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/Disposables/CancellationDisposable.cs
+++ b/Assets/Plugins/UniRx/Scripts/Disposables/CancellationDisposable.cs
@@ -16,6 +16,7 @@ namespace UniRx
     public sealed class CancellationDisposable : ICancelable
     {
         private readonly CancellationTokenSource _cts;
+        private readonly bool _isCtsInternal;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:System.Reactive.Disposables.CancellationDisposable"/> class that uses an existing <seealso cref="T:System.Threading.CancellationTokenSource"/>.
@@ -36,6 +37,7 @@ namespace UniRx
         public CancellationDisposable()
             : this(new CancellationTokenSource())
         {
+            _isCtsInternal = true;
         }
 
         /// <summary>
@@ -51,7 +53,15 @@ namespace UniRx
         /// </summary>
         public void Dispose()
         {
-            _cts.Cancel();
+            if (!IsDisposed)
+            {
+                _cts.Cancel();
+            }
+
+            if (_isCtsInternal)
+            {
+                _cts.Dispose();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes the issue where the `CancellationTokenSource` created within `CancellationDisposable` is not properly disposed of. For more details, see [Issue #535](https://github.com/neuecc/UniRx/issues/535).

Clarification on the following code block:

```csharp
if (!IsDisposed)
{
    _cts.Cancel();
}
```

The `Dispose()` method is designed to be idempotent, allowing for multiple invocations. If a `CancellationTokenSource` object is created inside `CancellationDisposable` and gets disposed during the initial call to `Dispose()`, subsequent attempts to cancel it will result in an exception.